### PR TITLE
Fixing issues so that we pass integration tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ result = self._http_client.post("/build", files=files, json_data=instructions)
 ```
 
 ### Key Learnings from split_pdf Implementation
-- **Page Ranges**: Use `{"start": 0, "end": 5}` (0-based, end exclusive) and `{"start": 10}` (to end)
+- **Page Ranges**: Use `{"start": 0, "end": 4}` (0-based, end inclusive) and `{"start": 10}` (to end)
 - **Multiple Operations**: Some tools require multiple API calls (one per page range/operation)
 - **Error Handling**: API returns 400 with detailed errors when parameters are invalid
 - **Testing Strategy**: Focus on integration tests with live API rather than unit test mocking

--- a/PR_CONTENT.md
+++ b/PR_CONTENT.md
@@ -7,14 +7,14 @@ This PR adds 8 new direct API methods that were missing from the Python client, 
 
 ### 1. Create Redactions (3 methods for different strategies)
 - `create_redactions_preset()` - Use built-in patterns for common sensitive data
-  - Presets: social-security-number, credit-card-number, email, phone-number, date, currency
+  - Presets: social-security-number, credit-card-number, email-address, international-phone-number, north-american-phone-number, date, time, us-zip-code
 - `create_redactions_regex()` - Custom regex patterns for flexible redaction
 - `create_redactions_text()` - Exact text matches with case sensitivity options
 
 ### 2. PDF Optimization
 - `optimize_pdf()` - Reduce file size with multiple optimization options:
   - Grayscale conversion (text, graphics, images)
-  - Image quality reduction (1-100)
+  - Image optimization quality (1-4, where 4 is most optimized)
   - Linearization for web viewing
   - Option to disable images entirely
 
@@ -82,7 +82,7 @@ client.apply_redactions("redacted.pdf", output_path="final.pdf")
 client.optimize_pdf(
     "large_document.pdf",
     grayscale_images=True,
-    reduce_image_quality=50,
+    image_optimization_quality=4,
     linearize=True,
     output_path="optimized.pdf"
 )

--- a/SUPPORTED_OPERATIONS.md
+++ b/SUPPORTED_OPERATIONS.md
@@ -171,8 +171,8 @@ Splits a PDF into multiple documents by page ranges.
 parts = client.split_pdf(
     "document.pdf", 
     page_ranges=[
-        {"start": 0, "end": 5},      # Pages 1-5
-        {"start": 5, "end": 10},     # Pages 6-10
+        {"start": 0, "end": 4},      # Pages 1-5
+        {"start": 5, "end": 9},      # Pages 6-10
         {"start": 10}                # Pages 11 to end
     ]
 )
@@ -180,7 +180,7 @@ parts = client.split_pdf(
 # Save to specific files
 client.split_pdf(
     "document.pdf",
-    page_ranges=[{"start": 0, "end": 2}, {"start": 2}],
+    page_ranges=[{"start": 0, "end": 1}, {"start": 2}],
     output_paths=["part1.pdf", "part2.pdf"]
 )
 
@@ -264,7 +264,7 @@ Sets custom labels/numbering for specific page ranges in a PDF.
 - `labels`: List of label configurations. Each dict must contain:
   - `pages`: Page range dict with `start` (required) and optionally `end`
   - `label`: String label to apply to those pages
-  - Page ranges use 0-based indexing where `end` is exclusive.
+  - Page ranges use 0-based indexing where `end` is inclusive.
 - `output_path`: Optional path to save the output file
 
 **Returns:**
@@ -276,8 +276,8 @@ Sets custom labels/numbering for specific page ranges in a PDF.
 client.set_page_label(
     "document.pdf",
     labels=[
-        {"pages": {"start": 0, "end": 3}, "label": "Introduction"},
-        {"pages": {"start": 3, "end": 10}, "label": "Chapter 1"},
+        {"pages": {"start": 0, "end": 2}, "label": "Introduction"},
+        {"pages": {"start": 3, "end": 9}, "label": "Chapter 1"},
         {"pages": {"start": 10}, "label": "Appendix"}
     ],
     output_path="labeled_document.pdf"
@@ -286,7 +286,7 @@ client.set_page_label(
 # Set label for single page
 client.set_page_label(
     "document.pdf",
-    labels=[{"pages": {"start": 0, "end": 1}, "label": "Cover Page"}]
+    labels=[{"pages": {"start": 0, "end": 0}, "label": "Cover Page"}]
 )
 ```
 
@@ -318,7 +318,7 @@ client.build(input_file="report.docx") \
 client.build(input_file="document.pdf") \
     .add_step("rotate-pages", {"degrees": 90}) \
     .set_page_labels([
-        {"pages": {"start": 0, "end": 3}, "label": "Introduction"},
+        {"pages": {"start": 0, "end": 2}, "label": "Introduction"},
         {"pages": {"start": 3}, "label": "Content"}
     ]) \
     .execute(output_path="labeled_document.pdf")

--- a/src/nutrient_dws/builder.py
+++ b/src/nutrient_dws/builder.py
@@ -87,15 +87,15 @@ class BuildAPIWrapper:
             labels: List of label configurations. Each dict must contain:
                    - 'pages': Page range dict with 'start' (required) and optionally 'end'
                    - 'label': String label to apply to those pages
-                   Page ranges use 0-based indexing where 'end' is exclusive.
+                   Page ranges use 0-based indexing where 'end' is inclusive.
 
         Returns:
             Self for method chaining.
 
         Example:
             >>> builder.set_page_labels([
-        ...     {"pages": {"start": 0, "end": 3}, "label": "Introduction"},
-        ...     {"pages": {"start": 3, "end": 10}, "label": "Chapter 1"},
+        ...     {"pages": {"start": 0, "end": 2}, "label": "Introduction"},
+        ...     {"pages": {"start": 3, "end": 9}, "label": "Chapter 1"},
         ...     {"pages": {"start": 10}, "label": "Appendix"}
         ... ])
         """

--- a/tests/integration/test_direct_api_integration.py
+++ b/tests/integration/test_direct_api_integration.py
@@ -7,6 +7,7 @@ test all Direct API methods against the live Nutrient DWS API.
 import pytest
 
 from nutrient_dws import NutrientClient
+from nutrient_dws.file_handler import get_pdf_page_count
 
 try:
     from . import integration_config  # type: ignore[attr-defined]
@@ -253,7 +254,7 @@ class TestDirectAPIIntegration:
         """Test split_pdf method with live API."""
         # Test splitting PDF into two parts - multi-page PDF has 3 pages
         page_ranges = [
-            {"start": 0, "end": 1},  # First page
+            {"start": 0, "end": 0},  # First page
             {"start": 1},  # Remaining pages
         ]
 
@@ -269,12 +270,17 @@ class TestDirectAPIIntegration:
         for pdf_bytes in result:
             assert_is_pdf(pdf_bytes)
 
+        # Verify the number of pages in each output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result[0]) == 1  # First PDF should have 1 page
+        assert get_pdf_page_count(result[1]) == total_page_count - 1  # Second PDF should have the remaining pages
+
     def test_split_pdf_with_output_files(self, client, sample_multipage_pdf_path, tmp_path):
         """Test split_pdf method saving to output files."""
         output_paths = [str(tmp_path / "page1.pdf"), str(tmp_path / "remaining.pdf")]
 
         page_ranges = [
-            {"start": 0, "end": 1},  # First page
+            {"start": 0, "end": 0},  # First page
             {"start": 1},  # Remaining pages
         ]
 
@@ -291,10 +297,17 @@ class TestDirectAPIIntegration:
         assert (tmp_path / "page1.pdf").stat().st_size > 0
         assert_is_pdf(str(tmp_path / "page1.pdf"))
 
+        # Verify the number of pages in the first output PDF
+        assert get_pdf_page_count(str(tmp_path / "page1.pdf")) == 1  # First PDF should have 1 page
+
         # Second file should exist since sample PDF has multiple pages
         assert (tmp_path / "remaining.pdf").exists()
         assert (tmp_path / "remaining.pdf").stat().st_size > 0
         assert_is_pdf(str(tmp_path / "remaining.pdf"))
+
+        # Verify the number of pages in the second output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(str(tmp_path / "remaining.pdf")) == total_page_count - 1 # Second PDF should have remaining pages
 
     def test_split_pdf_no_ranges_error(self, client, sample_pdf_path):
         """Test split_pdf with no ranges returns first page by default."""
@@ -306,6 +319,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result[0], bytes)
         assert len(result[0]) > 0
         assert_is_pdf(result[0])
+
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result[0]) == 1  # Should contain only the first page
 
     def test_split_pdf_output_paths_length_mismatch_error(self, client, sample_pdf_path):
         """Test split_pdf method with mismatched output_paths and page_ranges lengths."""
@@ -333,6 +349,9 @@ class TestDirectAPIIntegration:
         assert len(result) > 0
         assert_is_pdf(result)
 
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 2  # Should have 2 pages (duplicated the first page)
+
     def test_duplicate_pdf_pages_reorder(self, client, sample_multipage_pdf_path):
         """Test duplicate_pdf_pages method with page reordering."""
         # Test reordering pages (multi-page PDF has 3 pages)
@@ -341,6 +360,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 2  # Should have 2 pages (page 2 and page 1)
 
     def test_duplicate_pdf_pages_with_output_file(
         self, client, sample_multipage_pdf_path, tmp_path
@@ -361,6 +383,9 @@ class TestDirectAPIIntegration:
         assert (tmp_path / "duplicated.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
 
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(output_path) == 3  # Should have 3 pages (page 1, page 1, page 2)
+
     def test_duplicate_pdf_pages_negative_indexes(self, client, sample_pdf_path):
         """Test duplicate_pdf_pages method with negative indexes."""
         # Test using negative indexes (last page - works with single-page PDF)
@@ -369,6 +394,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 3  # Should have 3 pages (last page, first page, last page)
 
     def test_duplicate_pdf_pages_empty_indexes_error(self, client, sample_pdf_path):
         """Test duplicate_pdf_pages method with empty page_indexes raises error."""
@@ -385,6 +413,10 @@ class TestDirectAPIIntegration:
         assert len(result) > 0
         assert_is_pdf(result)
 
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count - 1  # Should have 2 pages (deleted first page from 3-page PDF)
+
     def test_delete_pdf_pages_multiple(self, client, sample_multipage_pdf_path):
         """Test delete_pdf_pages method with multiple page deletion."""
         # Test deleting multiple pages (deleting pages 1 and 3 from 3-page PDF)
@@ -393,6 +425,10 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count - 2  # Should have 1 page (deleted pages 1 and 3 from 3-page PDF)
 
     def test_delete_pdf_pages_with_output_file(self, client, sample_multipage_pdf_path, tmp_path):
         """Test delete_pdf_pages method saving to output file."""
@@ -410,6 +446,10 @@ class TestDirectAPIIntegration:
         assert (tmp_path / "pages_deleted.pdf").exists()
         assert (tmp_path / "pages_deleted.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
+
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(output_path) == total_page_count - 1  # Should have 2 pages (deleted page 2 from 3-page PDF)
 
     def test_delete_pdf_pages_negative_indexes_error(self, client, sample_pdf_path):
         """Test delete_pdf_pages method with negative indexes raises error."""
@@ -431,6 +471,10 @@ class TestDirectAPIIntegration:
         assert len(result) > 0
         assert_is_pdf(result)
 
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count - 2  # Should have 1 page (deleted pages 1 and 2 from 3-page PDF)
+
     # Tests for add_page
     def test_add_page_at_beginning(self, client, sample_pdf_path):
         """Test add_page method inserting at the beginning."""
@@ -440,6 +484,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_multiple_pages(self, client, sample_multipage_pdf_path):
         """Test add_page method with multiple pages."""
@@ -449,6 +496,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 3
 
     def test_add_page_at_end(self, client, sample_pdf_path):
         """Test add_page method inserting at the end."""
@@ -458,6 +508,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 2
 
     def test_add_page_before_specific_page(self, client, sample_multipage_pdf_path):
         """Test add_page method inserting before a specific page."""
@@ -467,6 +520,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_custom_size_orientation(self, client, sample_pdf_path):
         """Test add_page method with custom page size and orientation."""
@@ -482,6 +538,9 @@ class TestDirectAPIIntegration:
         assert isinstance(result, bytes)
         assert len(result) > 0
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 2
 
     def test_add_page_with_output_file(self, client, sample_multipage_pdf_path, tmp_path):
         """Test add_page method saving to output file."""
@@ -499,6 +558,9 @@ class TestDirectAPIIntegration:
         assert (tmp_path / "with_blank_pages.pdf").exists()
         assert (tmp_path / "with_blank_pages.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_multipage_pdf_path)
+        assert get_pdf_page_count(output_path) == total_page_count + 2
 
     def test_add_page_different_page_sizes(self, client, sample_pdf_path):
         """Test add_page method with different page sizes."""
@@ -511,6 +573,9 @@ class TestDirectAPIIntegration:
             assert isinstance(result, bytes)
             assert len(result) > 0
             assert_is_pdf(result)
+            # Verify the number of pages in the output PDF
+            total_page_count = get_pdf_page_count(sample_pdf_path)
+            assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_invalid_page_count_error(self, client, sample_pdf_path):
         """Test add_page method with invalid page_count raises error."""
@@ -538,7 +603,7 @@ class TestDirectAPIIntegration:
     # Tests for set_page_label
     def test_set_page_label_integration(self, client, sample_pdf_path, tmp_path):
         """Test set_page_label method with live API."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "Cover"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "Cover"}]
 
         output_path = str(tmp_path / "labeled.pdf")
 
@@ -552,7 +617,7 @@ class TestDirectAPIIntegration:
 
     def test_set_page_label_return_bytes(self, client, sample_pdf_path):
         """Test set_page_label method returning bytes."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "i"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "i"}]
 
         # Test getting bytes back
         result = client.set_page_label(sample_pdf_path, labels)
@@ -564,8 +629,8 @@ class TestDirectAPIIntegration:
     def test_set_page_label_multiple_ranges(self, client, sample_multipage_pdf_path):
         """Test set_page_label method with multiple page ranges."""
         labels = [
-            {"pages": {"start": 0, "end": 1}, "label": "i"},
-            {"pages": {"start": 1, "end": 2}, "label": "intro"},
+            {"pages": {"start": 0, "end": 0}, "label": "i"},
+            {"pages": {"start": 1, "end": 1}, "label": "intro"},
         ]
 
         result = client.set_page_label(sample_multipage_pdf_path, labels)
@@ -576,7 +641,7 @@ class TestDirectAPIIntegration:
 
     def test_set_page_label_single_page(self, client, sample_pdf_path):
         """Test set_page_label method with single page label."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "Cover Page"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "Cover Page"}]
 
         result = client.set_page_label(sample_pdf_path, labels)
 

--- a/tests/integration/test_live_api.py
+++ b/tests/integration/test_live_api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from nutrient_dws import NutrientClient
+from nutrient_dws.file_handler import get_pdf_page_count
 
 try:
     from . import integration_config  # type: ignore[attr-defined]
@@ -104,7 +105,7 @@ class TestLiveAPI:
         """Test split_pdf method with live API."""
         # Test splitting PDF into two parts - sample PDF should have multiple pages
         page_ranges = [
-            {"start": 0, "end": 1},  # First page
+            {"start": 0, "end": 0},  # First page
             {"start": 1},  # Remaining pages
         ]
 
@@ -120,12 +121,18 @@ class TestLiveAPI:
         for pdf_bytes in result:
             assert_is_pdf(pdf_bytes)
 
+        # Verify the number of pages in each output PDF
+        assert get_pdf_page_count(result[0]) == 1  # First PDF should have 1 page
+        # The second PDF should have the remaining pages (total pages - 1)
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result[1]) == total_pages - 1
+
     def test_split_pdf_with_output_files(self, client, sample_pdf_path, tmp_path):
         """Test split_pdf method saving to output files."""
         output_paths = [str(tmp_path / "page1.pdf"), str(tmp_path / "remaining.pdf")]
 
         page_ranges = [
-            {"start": 0, "end": 1},  # First page
+            {"start": 0, "end": 0},  # First page
             {"start": 1},  # Remaining pages
         ]
 
@@ -142,10 +149,18 @@ class TestLiveAPI:
         assert (tmp_path / "page1.pdf").stat().st_size > 0
         assert_is_pdf(str(tmp_path / "page1.pdf"))
 
+        # Verify the number of pages in the first output PDF
+        assert get_pdf_page_count(str(tmp_path / "page1.pdf")) == 1  # First PDF should have 1 page
+
         # Second file should exist since sample PDF has multiple pages
         assert (tmp_path / "remaining.pdf").exists()
         assert (tmp_path / "remaining.pdf").stat().st_size > 0
         assert_is_pdf(str(tmp_path / "remaining.pdf"))
+
+        # Verify the number of pages in the second output PDF
+        # The second PDF should have the remaining pages (total pages - 1)
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(str(tmp_path / "remaining.pdf")) == total_pages - 1
 
     def test_split_pdf_single_page_default(self, client, sample_pdf_path):
         """Test split_pdf with default behavior (single page)."""
@@ -160,9 +175,12 @@ class TestLiveAPI:
         # Verify result is a valid PDF
         assert_is_pdf(result[0])
 
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result[0]) == 1  # Should contain only the first page
+
     def test_set_page_label_integration(self, client, sample_pdf_path, tmp_path):
         """Test set_page_label method with live API."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "Cover"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "Cover"}]
 
         output_path = str(tmp_path / "labeled.pdf")
 
@@ -176,7 +194,7 @@ class TestLiveAPI:
 
     def test_set_page_label_return_bytes(self, client, sample_pdf_path):
         """Test set_page_label method returning bytes."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "i"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "i"}]
 
         # Test getting bytes back
         result = client.set_page_label(sample_pdf_path, labels)
@@ -188,9 +206,9 @@ class TestLiveAPI:
     def test_set_page_label_multiple_ranges(self, client, sample_pdf_path):
         """Test set_page_label method with multiple page ranges."""
         labels = [
-            {"pages": {"start": 0, "end": 1}, "label": "i"},
-            {"pages": {"start": 1, "end": 2}, "label": "intro"},
-            {"pages": {"start": 2, "end": 3}, "label": "final"},
+            {"pages": {"start": 0, "end": 0}, "label": "i"},
+            {"pages": {"start": 1, "end": 1}, "label": "intro"},
+            {"pages": {"start": 2, "end": 2}, "label": "final"},
         ]
 
         result = client.set_page_label(sample_pdf_path, labels)
@@ -201,7 +219,7 @@ class TestLiveAPI:
 
     def test_set_page_label_single_page(self, client, sample_pdf_path):
         """Test set_page_label method with single page label."""
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "Cover Page"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "Cover Page"}]
 
         result = client.set_page_label(sample_pdf_path, labels)
 
@@ -239,6 +257,9 @@ class TestLiveAPI:
         # Verify result is a valid PDF
         assert_is_pdf(result)
 
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 2  # Should have 2 pages (duplicated the first page)
+
     def test_duplicate_pdf_pages_reorder(self, client, sample_pdf_path):
         """Test duplicate_pdf_pages method with page reordering."""
         # Test reordering pages (assumes sample PDF has at least 2 pages)
@@ -249,6 +270,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 2  # Should have 2 pages (page 2 and page 1)
 
     def test_duplicate_pdf_pages_with_output_file(self, client, sample_pdf_path, tmp_path):
         """Test duplicate_pdf_pages method saving to output file."""
@@ -267,6 +291,9 @@ class TestLiveAPI:
         assert (tmp_path / "duplicated.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
 
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(output_path) == 3  # Should have 3 pages (page 1, page 1, page 2)
+
     def test_duplicate_pdf_pages_negative_indexes(self, client, sample_pdf_path):
         """Test duplicate_pdf_pages method with negative indexes."""
         # Test using negative indexes (last page)
@@ -277,6 +304,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        assert get_pdf_page_count(result) == 3  # Should have 3 pages (last page, first page, last page)
 
     def test_duplicate_pdf_pages_empty_indexes_error(self, client, sample_pdf_path):
         """Test duplicate_pdf_pages method with empty page_indexes raises error."""
@@ -294,6 +324,10 @@ class TestLiveAPI:
         # Verify result is a valid PDF
         assert_is_pdf(result)
 
+        # Verify the number of pages in the output PDF
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_pages - 1  # Should have one less page than original
+
     def test_delete_pdf_pages_multiple(self, client, sample_pdf_path):
         """Test delete_pdf_pages method with multiple page deletion."""
         # Test deleting multiple pages
@@ -304,6 +338,11 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        # Should have two less pages than original (deleted pages 1 and 3)
+        assert get_pdf_page_count(result) == total_pages - 2
 
     def test_delete_pdf_pages_with_output_file(self, client, sample_pdf_path, tmp_path):
         """Test delete_pdf_pages method saving to output file."""
@@ -319,6 +358,11 @@ class TestLiveAPI:
         assert (tmp_path / "pages_deleted.pdf").exists()
         assert (tmp_path / "pages_deleted.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
+
+        # Verify the number of pages in the output PDF
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        # Should have one less page than original (deleted page 2)
+        assert get_pdf_page_count(output_path) == total_pages - 1
 
     def test_delete_pdf_pages_negative_indexes_error(self, client, sample_pdf_path):
         """Test delete_pdf_pages method with negative indexes raises error."""
@@ -341,6 +385,11 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+
+        # Verify the number of pages in the output PDF
+        total_pages = get_pdf_page_count(sample_pdf_path)
+        # Should have two less pages than original (deleted pages 1 and 2)
+        assert get_pdf_page_count(result) == total_pages - 2
 
     @pytest.fixture
     def sample_docx_path(self):
@@ -396,6 +445,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_multiple_pages(self, client, sample_pdf_path):
         """Test add_page method with multiple pages."""
@@ -407,6 +459,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 3
 
     def test_add_page_at_end(self, client, sample_pdf_path):
         """Test add_page method inserting at the end."""
@@ -418,6 +473,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 2
 
     def test_add_page_before_specific_page(self, client, sample_pdf_path):
         """Test add_page method inserting before a specific page."""
@@ -429,6 +487,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_custom_size_orientation(self, client, sample_pdf_path):
         """Test add_page method with custom page size and orientation."""
@@ -446,6 +507,9 @@ class TestLiveAPI:
 
         # Verify result is a valid PDF
         assert_is_pdf(result)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(result) == total_page_count + 2
 
     def test_add_page_with_output_file(self, client, sample_pdf_path, tmp_path):
         """Test add_page method saving to output file."""
@@ -463,6 +527,9 @@ class TestLiveAPI:
         assert (tmp_path / "with_blank_pages.pdf").exists()
         assert (tmp_path / "with_blank_pages.pdf").stat().st_size > 0
         assert_is_pdf(output_path)
+        # Verify the number of pages in the output PDF
+        total_page_count = get_pdf_page_count(sample_pdf_path)
+        assert get_pdf_page_count(output_path) == total_page_count + 2
 
     def test_add_page_different_page_sizes(self, client, sample_pdf_path):
         """Test add_page method with different page sizes."""
@@ -475,6 +542,9 @@ class TestLiveAPI:
             assert isinstance(result, bytes)
             assert len(result) > 0
             assert_is_pdf(result)
+            # Verify the number of pages in the output PDF
+            total_page_count = get_pdf_page_count(sample_pdf_path)
+            assert get_pdf_page_count(result) == total_page_count + 1
 
     def test_add_page_invalid_page_count_error(self, client, sample_pdf_path):
         """Test add_page method with invalid page_count raises error."""

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -454,8 +454,8 @@ class TestBuilderEdgeCases:
         builder = BuildAPIWrapper(None, "test.pdf")
 
         labels = [
-            {"pages": {"start": 0, "end": 3}, "label": "Introduction"},
-            {"pages": {"start": 3, "end": 10}, "label": "Chapter 1"},
+            {"pages": {"start": 0, "end": 2}, "label": "Introduction"},
+            {"pages": {"start": 3, "end": 9}, "label": "Chapter 1"},
             {"pages": {"start": 10}, "label": "Appendix"},
         ]
 
@@ -468,7 +468,7 @@ class TestBuilderEdgeCases:
         """Test page labels can be chained with other operations."""
         builder = BuildAPIWrapper(None, "test.pdf")
 
-        labels = [{"pages": {"start": 0, "end": 1}, "label": "Cover"}]
+        labels = [{"pages": {"start": 0, "end": 0}, "label": "Cover"}]
 
         result = (
             builder.add_step("rotate-pages", options={"degrees": 90})


### PR DESCRIPTION
> This is Austin Nguyen from the AI team. I'm making a PR from a forked repo since I don't have edit permission on the original repo yet. Going to delete this fork once this PR merged/closed

Took a look through the project and also solved the failing integration tests. I will note down here the issues, as well as my though on how we can prevent the AI from making such mistakes in the future.
- The AI mistakenly think that the Page Range is end-exclusive, while it's actually end-inclusive. This is actually not 100% the AI's fault. From reading the documentation alone I couldn't find the any details about whether it is end-inclusive or not. Ultimately had to tried it to know for sure. This is a bit concerning since the mistake is actually way back and only recently did it get caught by a test case.
- The AI seems to hallucinate the API for the newly added tools, making up parameters that aren't there or misnaming the parameters
- The AI seems to not have an understanding of InstantJSON

Overall I'm impressed how far it got actually and it is perfectly within my expectation that the AI generated code will make mistakes that require doublechecking from a human (which is kinda what I'm doing right now). Looking forward:
- I think it's important to use type safety checks whenever possible on AI generated codes. Albeit it's harder to do on Python, but type safety make it a bit easier for the AI to catch it's own mistake, or for a human reviewer to know what's wrong
- On the topic of writing documentation for LLMs. I think we can make our OpenAPI YAML a bit easier to find/crawl. Right now it took far too many clicks for someone to get from the main landing page for DWS to get to the OpenAPI YAML file:
  - https://www.nutrient.io/
  - https://www.nutrient.io/api/
  - https://www.nutrient.io/api/documentation/ (You can only get to this page by going to the footer of the previous page)
  - https://www.nutrient.io/api/documentation/developer-guides/api-overview/ (You have to know exactly where to click on the right sidebar to get to this page)
  - https://www.nutrient.io/api/documentation/developer-guides/api-reference/ (A bit hidden to get to here)
  - https://www.nutrient.io/api/reference/public/ (a download button for the OpenAPI yaml is here)

Maybe a decent compromise is to have the Redocly/OpenAPI page at the footer of the https://www.nutrient.io/api/ page