### PR TITLE
Add framework quickstart snippets to Python client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ from nutrient_dws import NutrientClient
 client = NutrientClient(api_key='your_api_key')
 ```
 
+## Framework Quickstarts
+
+Framework-oriented snippets are available in `examples/src/`:
+
+- `framework_openai_agents.py`
+- `framework_langchain.py`
+- `framework_crewai.py`
+
+Syntax-check commands:
+
+```bash
+python -m py_compile examples/src/framework_openai_agents.py
+python -m py_compile examples/src/framework_langchain.py
+python -m py_compile examples/src/framework_crewai.py
+```
+
 ## Direct Methods
 
 The client provides numerous async methods for document processing:

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,9 @@ This example project demonstrates how to use the Nutrient DWS Python Client for 
 - `src/` - Contains Python source files
   - `direct_method.py` - Examples using direct method calls
   - `workflow.py` - Examples using the workflow builder pattern
+  - `framework_openai_agents.py` - OpenAI Agents SDK integration sketch
+  - `framework_langchain.py` - LangChain/LangGraph integration sketch
+  - `framework_crewai.py` - CrewAI integration sketch
 - `output/` - Directory where processed files will be saved
 - `.env.example` - Example environment variables file
 
@@ -121,6 +124,30 @@ This will:
 2. Create a document merging with watermark workflow
 3. Extract text with JSON output
 4. Execute a complex multi-step workflow
+
+### Framework Examples
+
+These examples are intentionally minimal and focus on framework wiring:
+
+Install optional framework dependencies first:
+
+```bash
+pip install openai-agents langchain langchain-openai langgraph crewai
+```
+
+```bash
+python src/framework_openai_agents.py
+python src/framework_langchain.py
+python src/framework_crewai.py
+```
+
+Syntax-check only:
+
+```bash
+python -m py_compile src/framework_openai_agents.py
+python -m py_compile src/framework_langchain.py
+python -m py_compile src/framework_crewai.py
+```
 
 ## Output
 

--- a/examples/src/framework_crewai.py
+++ b/examples/src/framework_crewai.py
@@ -1,0 +1,49 @@
+import os
+
+from crewai import Agent, Crew, Task
+from nutrient_dws import NutrientClient
+
+
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+
+
+document_planner = Agent(
+    role="Document Workflow Planner",
+    goal="Design a robust Nutrient DWS processing pipeline for incoming files.",
+    backstory="You optimize OCR, extraction, and redaction workflows for accuracy."
+)
+
+document_reviewer = Agent(
+    role="Document QA Reviewer",
+    goal="Review proposed workflow plans for failure modes and compliance risks.",
+    backstory="You specialize in validating document automation quality."
+)
+
+plan_task = Task(
+    description=(
+        "Design a pipeline for ./examples/assets/sample.pdf that extracts text, "
+        "redacts emails, and exports a cleaned PDF."
+    ),
+    expected_output="A numbered execution plan with tool calls.",
+    agent=document_planner,
+)
+
+review_task = Task(
+    description=(
+        "Review the proposed pipeline. Flag risks and add fallback handling steps."
+    ),
+    expected_output="Risk review with concrete mitigations.",
+    agent=document_reviewer,
+)
+
+crew = Crew(
+    agents=[document_planner, document_reviewer],
+    tasks=[plan_task, review_task],
+    verbose=True,
+)
+
+
+if __name__ == "__main__":
+    # Keep a direct client reference so users see where DWS calls happen.
+    print(f"Client configured: {bool(client)}")
+    print(crew.kickoff())

--- a/examples/src/framework_crewai.py
+++ b/examples/src/framework_crewai.py
@@ -4,7 +4,7 @@ from crewai import Agent, Crew, Task
 from nutrient_dws import NutrientClient
 
 
-client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "api_key_placeholder"))
 
 
 document_planner = Agent(

--- a/examples/src/framework_langchain.py
+++ b/examples/src/framework_langchain.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+
+from langchain.tools import StructuredTool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+from nutrient_dws import NutrientClient
+
+
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+
+
+async def redact_emails(path: str) -> str:
+    result = await client.create_redactions_ai(
+        path,
+        criteria="Redact all email addresses.",
+        redaction_state="apply",
+    )
+    return str(result)
+
+
+tool = StructuredTool.from_function(
+    func=redact_emails,
+    coroutine=redact_emails,
+    name="redact_emails",
+    description="Redact email addresses from a document using Nutrient DWS.",
+)
+
+
+async def main() -> None:
+    model = ChatOpenAI(
+        model="gpt-4.1-mini",
+        api_key=os.getenv("OPENAI_API_KEY", "sk-placeholder"),
+    )
+    agent = create_react_agent(model, [tool])
+    state = await agent.ainvoke(
+        {"messages": [("user", "Redact emails from ./assets/sample.pdf.")]}
+    )
+    print(state["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/src/framework_langchain.py
+++ b/examples/src/framework_langchain.py
@@ -7,7 +7,7 @@ from langgraph.prebuilt import create_react_agent
 from nutrient_dws import NutrientClient
 
 
-client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "api_key_placeholder"))
 
 
 async def redact_emails(path: str) -> str:

--- a/examples/src/framework_openai_agents.py
+++ b/examples/src/framework_openai_agents.py
@@ -1,0 +1,34 @@
+import asyncio
+import os
+
+from agents import Agent, Runner, function_tool
+from nutrient_dws import NutrientClient
+
+
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+
+
+@function_tool
+async def extract_text(input_path: str) -> str:
+    """Extract text from a document using Nutrient DWS."""
+    result = await client.extract_text(input_path)
+    return str(result)
+
+
+assistant = Agent(
+    name="nutrient-openai-agents-demo",
+    instructions="Help users extract text and summarize document workflows.",
+    tools=[extract_text],
+)
+
+
+async def main() -> None:
+    run = await Runner.run(
+        assistant,
+        "Extract text from ./assets/sample.pdf and summarize it in three bullets.",
+    )
+    print(run.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/src/framework_openai_agents.py
+++ b/examples/src/framework_openai_agents.py
@@ -5,7 +5,7 @@ from agents import Agent, Runner, function_tool
 from nutrient_dws import NutrientClient
 
 
-client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder"))
+client = NutrientClient(api_key=os.getenv("NUTRIENT_API_KEY", "api_key_placeholder"))
 
 
 @function_tool


### PR DESCRIPTION
## Summary
- add a `Framework Quickstarts` section in the root README
- add framework integration sketches in `examples/src/` for:
  - OpenAI Agents (`framework_openai_agents.py`)
  - LangChain/LangGraph (`framework_langchain.py`)
  - CrewAI (`framework_crewai.py`)
- update `examples/README.md` with:
  - framework file map
  - optional framework dependency install command
  - run and syntax-check commands
- align example asset paths with documented `cd examples` workflow
- use a supported redaction API in the LangChain example (`create_redactions_ai`)

## Validation
- `python3 -m py_compile examples/src/framework_openai_agents.py examples/src/framework_langchain.py examples/src/framework_crewai.py`
- `codex review --disable apps -c model_reasoning_effort='"low"' --uncommitted`
