### PR TITLE
Release/3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-05-27
+
 ### Added
 
 - `client.parse()` — first-class support for the Data Extraction API
@@ -17,12 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keyValueRegion, handwriting). Billed against **extraction credits**, a
   separate billing bucket from the **processor API credits** used by the
   other endpoints.
-- New types exported from `nutrient_dws`: `ParseResponse`,
-  `ParseInstructions`, `ParseMode`, `ParseOutputFormat`, `ParseElement`,
-  `ParseOutputBody`, `ParseOutputElements`, `ParseOutputMarkdown`,
-  `ParagraphElement`, `TableElement`, `TableCell`, `FormulaElement`,
-  `PictureElement`, `KeyValueRegionElement`, `KeyValuePair`,
-  `HandwritingElement`.
+- `NutrientClient(extract_api_key=...)` — optional constructor parameter
+  for the DWS Extract API key. `parse()` uses it for `/extraction/parse`
+  requests; every other method continues to use `api_key`. Falls back to
+  `api_key` when omitted (the path that becomes the default once global
+  DWS API keys roll out). Passing only a Processor `api_key` against
+  `/extraction/parse` is rejected by the server with `403`.
+- New types exported from `nutrient_dws`: `ExtractionCredits`,
+  `ParseResponse`, `ParseInstructions`, `ParseMode`, `ParseOutputFormat`,
+  `ParseElement`, `ParseOutputBody`, `ParseOutputElements`,
+  `ParseOutputMarkdown`, `ParagraphElement`, `TableElement`, `TableCell`,
+  `FormulaElement`, `PictureElement`, `KeyValueRegionElement`,
+  `KeyValuePair`, `HandwritingElement`.
 
 ## [3.0.0] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0] - 2026-05-27
 
-### Added
-
-- `client.parse()` — first-class support for the Data Extraction API
-  (`/extraction/parse`). Supports all four processing modes (`text`,
-  `structure`, `understand`, `agentic`) and both output shapes (spatial
-  elements and whole-document Markdown). Typed response model with
-  discriminated element variants (paragraph, table, formula, picture,
-  keyValueRegion, handwriting). Billed against **extraction credits**, a
-  separate billing bucket from the **processor API credits** used by the
-  other endpoints.
-- `NutrientClient(extract_api_key=...)` — optional constructor parameter
-  for the DWS Extract API key. `parse()` uses it for `/extraction/parse`
-  requests; every other method continues to use `api_key`. Falls back to
-  `api_key` when omitted (the path that becomes the default once global
-  DWS API keys roll out). Passing only a Processor `api_key` against
-  `/extraction/parse` is rejected by the server with `403`.
-- New types exported from `nutrient_dws`: `ExtractionCredits`,
-  `ParseResponse`, `ParseInstructions`, `ParseMode`, `ParseOutputFormat`,
-  `ParseElement`, `ParseOutputBody`, `ParseOutputElements`,
-  `ParseOutputMarkdown`, `ParagraphElement`, `TableElement`, `TableCell`,
-  `FormulaElement`, `PictureElement`, `KeyValueRegionElement`,
-  `KeyValuePair`, `HandwritingElement`.
+- Added `client.parse()` for the Data Extraction API (`/extraction/parse`)
+- Added `extract_api_key` constructor parameter — DWS Extract is a separate product with its own API key
 
 ## [3.0.0] - 2026-01-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ nutrient_dws_scripts = [
 
 [project]
 name = "nutrient-dws"
-version = "3.0.0"
+version = "3.1.0"
 description = "Python client library for Nutrient Document Web Services API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cutting `3.1.0` to publish `client.parse()` and the dual-key support landed in #47.

`3.0.0` → `3.1.0` (minor — additive, backwards compatible).

## What's in this release

- Added `client.parse()` for the Data Extraction API (`/extraction/parse`)
- Added `extract_api_key` constructor parameter — DWS Extract is a separate product with its own API key